### PR TITLE
Release 0.5.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ target/
 !**/src/test/**/target/
 pom.xml.versionsBackup
 .application.*
+**/.DS_Store
 
 ### STS ###
 .apt_generated

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
-def dockerRepo = "ghcr.io/cancogen-virus-seq/singularity"
-def gitHubRepo = "cancogen-virus-seq/singularity"
-def commit = "UNKNOWN"
-def version = "UNKNOWN"
+def dockerRepo = 'ghcr.io/cancogen-virus-seq/singularity'
+def gitHubRepo = 'cancogen-virus-seq/singularity'
+def commit = 'UNKNOWN'
+def version = 'UNKNOWN'
 
 pipeline {
     agent {
@@ -71,13 +71,15 @@ spec:
         stage('Test') {
             steps {
                 container('jdk') {
-                    sh "./mvnw test"
+                    sh './mvnw test'
                 }
             }
         }
         stage('Build & Publish Develop') {
             when {
-                branch "develop"
+                anyOf {
+                    branch 'develop'
+                }
             }
             steps {
                 container('docker') {
@@ -94,22 +96,24 @@ spec:
             }
         }
 
-       stage('deploy to cancogen-virus-seq-dev') {
-           when {
-               branch "develop"
-           }
-           steps {
-               build(job: "virusseq/update-app-version", parameters: [
-                   [$class: 'StringParameterValue', name: 'CANCOGEN_ENV', value: 'dev' ],
-                   [$class: 'StringParameterValue', name: 'TARGET_RELEASE', value: 'singularity'],
-                   [$class: 'StringParameterValue', name: 'NEW_APP_VERSION', value: "${version}-${commit}" ]
-               ])
-           }
-       }
+        stage('deploy to cancogen-virus-seq-dev') {
+            when {
+                anyOf {
+                    branch 'develop'
+                }
+            }
+            steps {
+                build(job: 'virusseq/update-app-version', parameters: [
+                    [$class: 'StringParameterValue', name: 'CANCOGEN_ENV', value: 'dev' ],
+                    [$class: 'StringParameterValue', name: 'TARGET_RELEASE', value: 'singularity'],
+                    [$class: 'StringParameterValue', name: 'NEW_APP_VERSION', value: "${version}-${commit}" ]
+                ])
+            }
+        }
 
         stage('Release & Tag') {
             when {
-                branch "main"
+                branch 'main'
             }
             steps {
                 container('docker') {

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.0</version>
+        <version>2.6.6</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>org.cancogen-virus-seq</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>org.cancogen-virus-seq</groupId>
     <artifactId>singularity</artifactId>
-    <version>0.5.0-SNAPSHOT</version>
+    <version>0.5.1</version>
     <name>singularity</name>
     <description>Singularity - All contributors, All files</description>
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>org.cancogen-virus-seq</groupId>
     <artifactId>singularity</artifactId>
-    <version>0.5.0</version>
+    <version>0.5.0-SNAPSHOT</version>
     <name>singularity</name>
     <description>Singularity - All contributors, All files</description>
     <properties>

--- a/src/main/java/org/cancogenvirusseq/singularity/components/base/ElasticSearchScroll.java
+++ b/src/main/java/org/cancogenvirusseq/singularity/components/base/ElasticSearchScroll.java
@@ -10,7 +10,7 @@ import org.cancogenvirusseq.singularity.components.model.AnalysisDocument;
 import org.cancogenvirusseq.singularity.config.elasticsearch.ElasticsearchProperties;
 import org.cancogenvirusseq.singularity.config.elasticsearch.ReactiveElasticSearchClientConfig;
 import org.elasticsearch.action.search.SearchRequest;
-import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.builder.SearchSourceBuilder;

--- a/src/main/java/org/cancogenvirusseq/singularity/components/pipelines/TotalCountsPipeline.java
+++ b/src/main/java/org/cancogenvirusseq/singularity/components/pipelines/TotalCountsPipeline.java
@@ -19,7 +19,7 @@ import org.cancogenvirusseq.singularity.components.events.EventEmitter;
 import org.cancogenvirusseq.singularity.components.model.TotalCounts;
 import org.cancogenvirusseq.singularity.config.elasticsearch.ElasticsearchProperties;
 import org.elasticsearch.action.search.SearchRequest;
-import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.aggregations.Aggregation;

--- a/src/main/java/org/cancogenvirusseq/singularity/components/utils/FileBundleUtils.java
+++ b/src/main/java/org/cancogenvirusseq/singularity/components/utils/FileBundleUtils.java
@@ -94,8 +94,9 @@ public class FileBundleUtils {
 
   private static final UnaryOperator<FileBundle> createTarOutputStream =
       fileBundle -> {
-        fileBundle.setArchiveTarOutputStream(
-            new TarArchiveOutputStream(fileBundle.getArchiveGzipOutputStream()));
+        TarArchiveOutputStream tarArchiveOutputStream = new TarArchiveOutputStream(fileBundle.getArchiveGzipOutputStream());
+        tarArchiveOutputStream.setBigNumberMode(TarArchiveOutputStream.BIGNUMBER_POSIX);
+        fileBundle.setArchiveTarOutputStream(tarArchiveOutputStream);
         return fileBundle;
       };
 


### PR DESCRIPTION
Includes:
- upgrade to Spring Boot 2.6.6
- restores the Release Page bundle functionalities, by increasing the max tar-able file size (as provided/implemented by @UmmulkiramR).