### PR TITLE
Total file counts implementation #38

### DIFF
--- a/src/main/java/org/cancogenvirusseq/singularity/components/events/KafkaEventEmitter.java
+++ b/src/main/java/org/cancogenvirusseq/singularity/components/events/KafkaEventEmitter.java
@@ -42,7 +42,7 @@ public class KafkaEventEmitter implements EventEmitter<Instant> {
   private final KafkaConsumerConfig kafkaConsumerConfig;
 
   @Value("${files.finalEventCheckSeconds}")
-  private final Integer finalEventCheckSeconds = 60; // default to 1 minute
+  private final Integer finalEventCheckSeconds = 300; // default to 1 minute
 
   private static final AtomicReference<Instant> lastEvent = new AtomicReference<>();
 

--- a/src/main/java/org/cancogenvirusseq/singularity/components/events/KafkaEventEmitter.java
+++ b/src/main/java/org/cancogenvirusseq/singularity/components/events/KafkaEventEmitter.java
@@ -42,7 +42,7 @@ public class KafkaEventEmitter implements EventEmitter<Instant> {
   private final KafkaConsumerConfig kafkaConsumerConfig;
 
   @Value("${files.finalEventCheckSeconds}")
-  private final Integer finalEventCheckSeconds = 300; // default to 5 minute
+  private final Integer finalEventCheckSeconds = 600; // default to 5 minute
 
   private static final AtomicReference<Instant> lastEvent = new AtomicReference<>();
 

--- a/src/main/java/org/cancogenvirusseq/singularity/components/events/KafkaEventEmitter.java
+++ b/src/main/java/org/cancogenvirusseq/singularity/components/events/KafkaEventEmitter.java
@@ -42,7 +42,7 @@ public class KafkaEventEmitter implements EventEmitter<Instant> {
   private final KafkaConsumerConfig kafkaConsumerConfig;
 
   @Value("${files.finalEventCheckSeconds}")
-  private final Integer finalEventCheckSeconds = 600; // default to 5 minute
+  private final Integer finalEventCheckSeconds = 600; // default to 10 minutes
 
   private static final AtomicReference<Instant> lastEvent = new AtomicReference<>();
 

--- a/src/main/java/org/cancogenvirusseq/singularity/components/events/KafkaEventEmitter.java
+++ b/src/main/java/org/cancogenvirusseq/singularity/components/events/KafkaEventEmitter.java
@@ -42,7 +42,7 @@ public class KafkaEventEmitter implements EventEmitter<Instant> {
   private final KafkaConsumerConfig kafkaConsumerConfig;
 
   @Value("${files.finalEventCheckSeconds}")
-  private final Integer finalEventCheckSeconds = 300; // default to 1 minute
+  private final Integer finalEventCheckSeconds = 300; // default to 5 minute
 
   private static final AtomicReference<Instant> lastEvent = new AtomicReference<>();
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -49,7 +49,7 @@ contributors:
   appendList:
 
 files:
-  finalEventCheckSeconds: 60
+  finalEventCheckSeconds: 300 #60
 
 intervalEventEmitter:
   intervalTimerSeconds: 600


### PR DESCRIPTION
The final event delay is increased from 1 min to 5 mins to make sure the final upload event finishes before the Elasticsearch is queried to calculate the total file and sample counts. 